### PR TITLE
add catches for IPv6 addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The most basic usage is to pass an array of IPv4 addresses into `AndrewAndante\S
 
 The most useful usage is to pass an array of CIDRs into `AndrewAndante\SubMuncher\SubMuncher::consolidate_subnets()`
 
-There are also a bunch of helper IP utility functions in the `Util` classe should you need to do some tweaking.
+There are also a bunch of helper IP utility functions in the `Util` class should you need to do some tweaking.
 
 You can also pass a second parameter that limits the number of rules returned. This invokes some magic to combine some subnets in a way that introduces the least number of additional IP addresses into the range as possible.
 

--- a/src/SubMuncher.php
+++ b/src/SubMuncher.php
@@ -25,7 +25,7 @@ class SubMuncher
         $sortedIPs = Util::sort_addresses($ips);
 
         foreach ($sortedIPs as $index => $ipv4) {
-            if (!Util::is_ipaddr($ipv4)) {
+            if (!Util::is_ipv4_addr($ipv4)) {
                 continue;
             }
             // If not last and the next IP is the next sequential one, we are at the beginning of a subnet
@@ -60,7 +60,7 @@ class SubMuncher
     public static function ip_range_to_subnet_array($startip, $endip)
     {
 
-        if (!Util::is_ipaddr($startip) || !Util::is_ipaddr($endip)) {
+        if (!Util::is_ipv4_addr($startip) || !Util::is_ipv4_addr($endip)) {
             return [];
         }
 

--- a/src/SubMuncher.php
+++ b/src/SubMuncher.php
@@ -25,6 +25,9 @@ class SubMuncher
         $sortedIPs = Util::sort_addresses($ips);
 
         foreach ($sortedIPs as $index => $ipv4) {
+            if (!Util::is_ipaddr($ipv4)) {
+                continue;
+            }
             // If not last and the next IP is the next sequential one, we are at the beginning of a subnet
             if (isset($sortedIPs[$index + 1]) && $sortedIPs[$index + 1] == Util::ip_after($ipv4)) {
                 // if we've already started, just keep going, else kick one off

--- a/src/SubMuncher.php
+++ b/src/SubMuncher.php
@@ -12,7 +12,7 @@ class SubMuncher
     }
 
     /**
-     * @param array $ipsArray
+     * @param string[] $ipsArray
      * @param int $max max number of rules returned
      * @return array
      */

--- a/src/Util.php
+++ b/src/Util.php
@@ -233,7 +233,9 @@ class Util
         $bitAddresses = [];
         $ipAddresses = [];
         foreach ($ipaddr as $ipv4) {
-            $bitAddresses[] = self::ip2ulong($ipv4);
+            if (self::is_ipaddr($ipv4)) {
+                $bitAddresses[] = self::ip2ulong($ipv4);
+            }
         }
         sort($bitAddresses);
         foreach ($bitAddresses as $raw) {
@@ -250,8 +252,10 @@ class Util
         $sortedCidrs = [];
         foreach ($cidrs as $cidr) {
             $parts = explode('/', $cidr);
-            $map[$parts[0]] = $parts[1];
-            $bitAddresses[] = self::ip2ulong($parts[0]);
+            if (self::is_ipaddr($parts[0])) {
+                $map[$parts[0]] = $parts[1];
+                $bitAddresses[] = self::ip2ulong($parts[0]);
+            }
         }
         sort($bitAddresses);
         foreach ($bitAddresses as $raw) {

--- a/src/Util.php
+++ b/src/Util.php
@@ -34,7 +34,7 @@ class Util
     }
 
     /* returns true if $ipaddr is a valid dotted IPv4 address */
-    public static function is_ipaddr($ipaddr)
+    public static function is_ipv4_addr($ipaddr)
     {
         if (!is_string($ipaddr)) {
             return false;
@@ -103,7 +103,7 @@ class Util
     */
     public static function ip_range_size($startip, $endip)
     {
-        if (self::is_ipaddr($startip) && self::is_ipaddr($endip)) {
+        if (self::is_ipv4_addr($startip) && self::is_ipv4_addr($endip)) {
             // Operate as unsigned long because otherwise it wouldn't work
             // when crossing over from 127.255.255.255 / 128.0.0.0 barrier
             return abs(self::ip2ulong($startip) - self::ip2ulong($endip)) + 1;
@@ -114,7 +114,7 @@ class Util
 
     public static function get_single_subnet($startip, $endip)
     {
-        if (!self::is_ipaddr($startip) || !self::is_ipaddr($endip)) {
+        if (!self::is_ipv4_addr($startip) || !self::is_ipv4_addr($endip)) {
             return null;
         }
 
@@ -178,7 +178,7 @@ class Util
     public static function cidr_to_ips_array($cidr)
     {
         $parts = explode('/', $cidr);
-        if (!self::is_ipaddr($parts[0])) {
+        if (!self::is_ipv4_addr($parts[0])) {
             return false;
         }
 
@@ -197,7 +197,7 @@ class Util
     /* return the subnet address given a host address and a subnet bit count */
     public static function gen_subnet($ipaddr, $bits)
     {
-        if (!self::is_ipaddr($ipaddr) || !is_numeric($bits)) {
+        if (!self::is_ipv4_addr($ipaddr) || !is_numeric($bits)) {
             return "";
         }
 
@@ -219,7 +219,7 @@ class Util
     a subnet bit count */
     public static function gen_subnet_max($ipaddr, $bits)
     {
-        if (!self::is_ipaddr($ipaddr) || !is_numeric($bits)) {
+        if (!self::is_ipv4_addr($ipaddr) || !is_numeric($bits)) {
             return "";
         }
 
@@ -233,7 +233,7 @@ class Util
         $bitAddresses = [];
         $ipAddresses = [];
         foreach ($ipaddr as $ipv4) {
-            if (self::is_ipaddr($ipv4)) {
+            if (self::is_ipv4_addr($ipv4)) {
                 $bitAddresses[] = self::ip2ulong($ipv4);
             }
         }
@@ -252,7 +252,7 @@ class Util
         $sortedCidrs = [];
         foreach ($cidrs as $cidr) {
             $parts = explode('/', $cidr);
-            if (self::is_ipaddr($parts[0])) {
+            if (self::is_ipv4_addr($parts[0])) {
                 $map[$parts[0]] = $parts[1];
                 $bitAddresses[] = self::ip2ulong($parts[0]);
             }

--- a/tests/php/SubMuncherIPv6Test.php
+++ b/tests/php/SubMuncherIPv6Test.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace AndrewAndante\SubMuncher\Test;
+
+use AndrewAndante\SubMuncher\SubMuncher;
+
+class SubMuncherIPv6Test extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @TODO remove this when we have actual IPv6 functionality
+     */
+    public function testIgnoresIPv6()
+    {
+        $this->assertEmpty(SubMuncher::consolidate(['::10', '::11']));
+        $this->assertEquals(
+            ['10.10.10.10/31'],
+            SubMuncher::consolidate(['10.10.10.10', '10.10.10.11', '::10', '::11'])
+        );
+    }
+}

--- a/tests/php/UtilTest.php
+++ b/tests/php/UtilTest.php
@@ -8,22 +8,22 @@ class UtilTest extends \PHPUnit_Framework_TestCase
 {
     public function testIsIPAddress()
     {
-        $this->assertTrue(Util::is_ipaddr('10.10.10.10'));
-        $this->assertTrue(Util::is_ipaddr('255.255.255.255'));
-        $this->assertTrue(Util::is_ipaddr('0.0.0.0'));
+        $this->assertTrue(Util::is_ipv4_addr('10.10.10.10'));
+        $this->assertTrue(Util::is_ipv4_addr('255.255.255.255'));
+        $this->assertTrue(Util::is_ipv4_addr('0.0.0.0'));
 
-        $this->assertFalse(Util::is_ipaddr(10));
-        $this->assertFalse(Util::is_ipaddr('10.100.1000.100000'));
-        $this->assertFalse(Util::is_ipaddr('10.10.10'));
-        $this->assertFalse(Util::is_ipaddr('IP ADDRESS'));
-        $this->assertFalse(Util::is_ipaddr(['10.10.10.10']));
+        $this->assertFalse(Util::is_ipv4_addr(10));
+        $this->assertFalse(Util::is_ipv4_addr('10.100.1000.100000'));
+        $this->assertFalse(Util::is_ipv4_addr('10.10.10'));
+        $this->assertFalse(Util::is_ipv4_addr('IP ADDRESS'));
+        $this->assertFalse(Util::is_ipv4_addr(['10.10.10.10']));
 
         /**
          * IPv6 should return false for now
          * @TODO update this when we add IPv6 functionality
          */
-        $this->assertFalse(Util::is_ipaddr('::10'));
-        $this->assertFalse(Util::is_ipaddr('2001:0db8:85a3:0000:0000:8a2e:0370:7334'));
+        $this->assertFalse(Util::is_ipv4_addr('::10'));
+        $this->assertFalse(Util::is_ipv4_addr('2001:0db8:85a3:0000:0000:8a2e:0370:7334'));
     }
 
     public function testIPLessThan()

--- a/tests/php/UtilTest.php
+++ b/tests/php/UtilTest.php
@@ -17,6 +17,13 @@ class UtilTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse(Util::is_ipaddr('10.10.10'));
         $this->assertFalse(Util::is_ipaddr('IP ADDRESS'));
         $this->assertFalse(Util::is_ipaddr(['10.10.10.10']));
+
+        /**
+         * IPv6 should return false for now
+         * @TODO update this when we add IPv6 functionality
+         */
+        $this->assertFalse(Util::is_ipaddr('::10'));
+        $this->assertFalse(Util::is_ipaddr('2001:0db8:85a3:0000:0000:8a2e:0370:7334'));
     }
 
     public function testIPLessThan()


### PR DESCRIPTION
In this current iteration it will simply skip over any non-IPv4 addresses. Could update to throw an Exception or error instead, but ignoring should be fine for our purposes.

Fixes #8 

@mateusz something for you to take a look at to go with https://github.com/silverstripeltd/rainforest/pull/618